### PR TITLE
Fix checkout for invalid addresses

### DIFF
--- a/app/code/community/OnePica/AvaTax/Model/Sales/Quote/Address.php
+++ b/app/code/community/OnePica/AvaTax/Model/Sales/Quote/Address.php
@@ -73,6 +73,11 @@ class OnePica_AvaTax_Model_Sales_Quote_Address extends Mage_Sales_Model_Quote_Ad
      * @return true|array
      */
     public function validate () {
+
+        if (! Mage::helper('avatax')->fullStopOnError()) {
+            return true;
+        }
+        
         $result = parent::validate();
 
         //if base validation fails, don't bother with additional validation


### PR DESCRIPTION
If Action On Error is configured to allow checkout to complete,
then return true in validate() before the parent class can
throw an exception
