### PR TITLE
Fixed wrong conditions for getting Gift Wrapper prices (new PR for develop branch)

### DIFF
--- a/app/code/community/OnePica/AvaTax/Model/Sales/Quote/Address/Total/Tax.php
+++ b/app/code/community/OnePica/AvaTax/Model/Sales/Quote/Address/Total/Tax.php
@@ -102,7 +102,7 @@ class OnePica_AvaTax_Model_Sales_Quote_Address_Total_Tax extends Mage_Sales_Mode
 					$this->_addBaseAmount($baseShippingTax);
 				}
 
-				if($address->getGwPrice()) {
+				if($address->getGwPrice() > 0) {
 					$gwOrderItem = new Varien_Object();
 					$gwOrderItem->setId(Mage::helper('avatax')->getGwOrderSku($store->getId()));
 					$gwOrderItem->setProductId(Mage::helper('avatax')->getGwOrderSku($store->getId()));
@@ -117,7 +117,7 @@ class OnePica_AvaTax_Model_Sales_Quote_Address_Total_Tax extends Mage_Sales_Mode
 					$this->_addBaseAmount($baseGwOrderTax);
 				}
 
-				if($address->getGwItemsPrice()) {
+				if($address->getGwItemsPrice() > 0) {
 					$gwIndividualItem = new Varien_Object();
 					$gwIndividualItem->setId(Mage::helper('avatax')->getGwItemsSku($store->getId()));
 					$gwIndividualItem->setProductId(Mage::helper('avatax')->getGwItemsSku($store->getId()));


### PR DESCRIPTION
from @rogyar 

Magento EE on the following request:

$address->getGwPrice()
might return (string) "0.0000"

Then condition

 if($address->getGwPrice())
will be TRUE 
It causes unnecessary calculations and even wrong taxes calculation. 
Glad to share this little fix with you. 
Thanks.
