### PR TITLE
Fixes Tax Calculation on Giftwrapped Orders

### DIFF
--- a/app/code/community/OnePica/AvaTax/Model/Sales/Quote/Address/Total/Tax.php
+++ b/app/code/community/OnePica/AvaTax/Model/Sales/Quote/Address/Total/Tax.php
@@ -107,7 +107,7 @@ class OnePica_AvaTax_Model_Sales_Quote_Address_Total_Tax extends Mage_Sales_Mode
 					$gwOrderItem->setId(Mage::helper('avatax')->getGwOrderSku($store->getId()));
 					$gwOrderItem->setProductId(Mage::helper('avatax')->getGwOrderSku($store->getId()));
 					$gwOrderItem->setAddress($address);
-					$baseGwOrderTax = $calculator->getItemTax($gwOrderItem);
+					$baseGwOrderTax = $calculator->getItemTax($baseGwOrderTax);
 					$gwOrderTax = Mage::app()->getStore()->convertPrice($gwOrderItem);
 
 					$address->setGwBaseTaxAmount($address->getGwBasePrice()+$baseGwOrderTax);


### PR DESCRIPTION
This line was causing the below exception to be thrown during checkout when enabling giftwrapping on an order that qualified for sales tax.

Notice: Object of class Varien_Object could not be converted to int