### PR TITLE
AV-419: Error is not displayed if empty field in blocks Logs&Queue or Data Mapping was saved in admin panel

### DIFF
--- a/app/code/community/OnePica/AvaTax/Model/Observer.php
+++ b/app/code/community/OnePica/AvaTax/Model/Observer.php
@@ -225,30 +225,6 @@ class OnePica_AvaTax_Model_Observer extends Mage_Core_Model_Abstract
         if ($ping !== true) {
             $errors[] = $ping;
         }
-        if (!Mage::getStoreConfig('tax/avatax/url', $storeId)) {
-            $errors[] = Mage::helper('avatax')->__('You must enter a connection URL');
-        }
-        if (!Mage::getStoreConfig('tax/avatax/account', $storeId)) {
-            $errors[] = Mage::helper('avatax')->__('You must enter an account number');
-        }
-        if (!Mage::getStoreConfig('tax/avatax/license', $storeId)) {
-            $errors[] = Mage::helper('avatax')->__('You must enter a license key');
-        }
-        if (!is_numeric(Mage::getStoreConfig('tax/avatax/log_lifetime'))) {
-            $errors[] = Mage::helper('avatax')->__('You must enter the number of days to keep log entries');
-        }
-        if (!Mage::getStoreConfig('tax/avatax/company_code', $storeId)) {
-            $errors[] = Mage::helper('avatax')->__('You must enter a company code');
-        }
-        if (!Mage::getStoreConfig('tax/avatax/shipping_sku', $storeId)) {
-            $errors[] = Mage::helper('avatax')->__('You must enter a shipping sku');
-        }
-        if (!Mage::getStoreConfig('tax/avatax/adjustment_positive_sku', $storeId)) {
-            $errors[] = Mage::helper('avatax')->__('You must enter an adjustment refund sku');
-        }
-        if (!Mage::getStoreConfig('tax/avatax/adjustment_negative_sku', $storeId)) {
-            $errors[] = Mage::helper('avatax')->__('You must enter an adjustment fee sku');
-        }
 
         if (!class_exists('SoapClient')) {
             $errors[] = Mage::helper('avatax')->__('The PHP class SoapClient is missing. It must be enabled to use this extension. See %s for details.', '<a href="http://www.php.net/manual/en/book.soap.php" target="_blank">http://www.php.net/manual/en/book.soap.php</a>');

--- a/app/code/community/OnePica/AvaTax/etc/system.xml
+++ b/app/code/community/OnePica/AvaTax/etc/system.xml
@@ -131,6 +131,7 @@
                             <label>Log Entry Lifetime</label>
                             <comment>Required. Days before entries are auto-purged.</comment>
                             <frontend_type>text</frontend_type>
+                            <validate>required-entry</validate>
                             <sort_order>120</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
@@ -140,6 +141,7 @@
                             <label>Successful Queue Lifetime</label>
                             <comment>Required. Days before entries are auto-purged.</comment>
                             <frontend_type>text</frontend_type>
+                            <validate>required-entry</validate>
                             <sort_order>122</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
@@ -148,6 +150,7 @@
                         <queue_failed_lifetime translate="label comment">
                             <label>Failed Queue Lifetime</label>
                             <comment>Required. Days before entries are auto-purged.</comment>
+                            <validate>required-entry</validate>
                             <frontend_type>text</frontend_type>
                             <sort_order>124</sort_order>
                             <show_in_default>1</show_in_default>
@@ -196,6 +199,7 @@
                             <label>Shipping Sku</label>
                             <comment>Required. The sku sent to denote shipping costs.</comment>
                             <frontend_type>text</frontend_type>
+                            <validate>required-entry</validate>
                             <sort_order>210</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -205,15 +209,17 @@
                             <label>Gift Wrap Order Sku</label>
                             <comment>Required. The sku sent to denote gift wrap order costs.</comment>
                             <frontend_type>text</frontend_type>
+                            <validate>required-entry</validate>
                             <sort_order>215</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </gw_order_sku>
-                                                <gw_items_sku translate="label comment">
+                        <gw_items_sku translate="label comment">
                             <label>Gift Wrap Items Sku</label>
                             <comment>Required. The sku sent to denote gift wrap items costs.</comment>
                             <frontend_type>text</frontend_type>
+                            <validate>required-entry</validate>
                             <sort_order>216</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -223,6 +229,7 @@
                             <label>Gift Wrap Printed Card Sku</label>
                             <comment>Required. The sku sent to denote gift wrap printed card costs.</comment>
                             <frontend_type>text</frontend_type>
+                            <validate>required-entry</validate>
                             <sort_order>217</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -232,6 +239,7 @@
                             <label>Adjustment Refund Sku</label>
                             <comment>Required. The sku sent to denote positive ajustments.</comment>
                             <frontend_type>text</frontend_type>
+                            <validate>required-entry</validate>
                             <sort_order>220</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -241,6 +249,7 @@
                             <label>Adjustment Fee Sku</label>
                             <comment>Required. The sku sent to denote negative ajustments.</comment>
                             <frontend_type>text</frontend_type>
+                            <validate>required-entry</validate>
                             <sort_order>230</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>

--- a/app/code/community/OnePica/AvaTax/etc/system.xml
+++ b/app/code/community/OnePica/AvaTax/etc/system.xml
@@ -52,6 +52,7 @@
                         <url translate="label">
                             <label>URL</label>
                             <frontend_type>text</frontend_type>
+                            <validate>required-entry</validate>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -60,6 +61,7 @@
                         <account translate="label">
                             <label>Account Number</label>
                             <frontend_type>text</frontend_type>
+                            <validate>required-entry</validate>
                             <sort_order>30</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -68,6 +70,7 @@
                         <license translate="label">
                             <label>License Key</label>
                             <frontend_type>text</frontend_type>
+                            <validate>required-entry</validate>
                             <sort_order>40</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -77,6 +80,7 @@
                             <label>Company Code</label>
                             <comment>Required. Your company code from the dashboard.</comment>
                             <frontend_type>text</frontend_type>
+                            <validate>required-entry</validate>
                             <sort_order>50</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>


### PR DESCRIPTION
- added validation 'required-entry' for the necessary fields