### PR TITLE
AV-49: Export logs file doesn't contain detailed log information

### DIFF
--- a/app/code/community/OnePica/AvaTax/Model/Export/Entity/Log.php
+++ b/app/code/community/OnePica/AvaTax/Model/Export/Entity/Log.php
@@ -36,6 +36,9 @@ class OnePica_AvaTax_Model_Export_Entity_Log extends OnePica_AvaTax_Model_Export
             'store_id',
             'level',
             'type',
+            'request',
+            'result',
+            'additional',
             'created_at'
         );
     }


### PR DESCRIPTION
- added 'request', 'result', 'additional' fields in exported file