### PR TITLE
Remove magento-composer-installer from require, move it to suggest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,14 +3,14 @@
     "type": "magento-module",
     "description": "This extension integrates Magento with AvaTax, a tax service provided by Avalara. ",
     "homepage": "http://www.magentocommerce.com/magento-connect/6760.html",
-    "require": {
-        "magento-hackathon/magento-composer-installer": "dev-master"
-    },
     "license": "OSL-3.0",
     "authors":[
         {
             "name":"One Pica",
             "homepage": "http://www.onepica.com/"
         }
-    ]
+    ],
+    "suggest": {
+        "magento-hackathon/magento-composer-installer": "For deploying Magento module packages."
+    }
 }


### PR DESCRIPTION
There are few issues with having "magento-composer-installer" in require section:

1. This is not really a dependency of this module. It only serves the purpose of deploying it into Magento structure (which if you ask me is an outside job).
2. By constraining "dev-master" version you're making this package incompatible to whoever uses the release-based version of "magento-composer-installer" package (which is the correct way actually).
I have `"magento-composer-installer": "~3"` constraint and it's incompatible with "dev-master".
3. Currently there are other installers (deployment packages) that serve the purpose of Magento composer installer. By constraining your package to only one of those you're making unnecessary restriction to whoever uses different installer.