### PR TITLE
AV-595: Normalization: enabled. Onepage Checkout Address Normalized Notice is not displayed after entering normalizable shipping address

### DIFF
--- a/app/code/community/OnePica/AvaTax/Block/Checkout/Onepage/Shipping/Method/Available.php
+++ b/app/code/community/OnePica/AvaTax/Block/Checkout/Onepage/Shipping/Method/Available.php
@@ -95,7 +95,7 @@ class OnePica_AvaTax_Block_Checkout_Onepage_Shipping_Method_Available extends Ma
         if ($this->getAddress()->getAddressNormalized()) {
             $notice = Mage::getSingleton('avatax/config')->getConfig('onepage_normalize_message');
             if ($notice) {
-                Mage::getSingleton('checkout/session')->addNotice($notice);
+                Mage::getSingleton('core/session')->addNotice($notice);
                 $additional .= $this->getMessagesBlock()->getGroupedHtml();
             }
         } elseif ($this->getAddress()->getAddressNotified()) {


### PR DESCRIPTION
- replaced checkout/session to core/session model for displaying notice
