### PR TITLE
Implemented AVTNG-747: Sends wrong adjustments if currency is not the same as the base currency.

### DIFF
--- a/app/code/community/OnePica/AvaTax/Model/Service/Avatax/Invoice.php
+++ b/app/code/community/OnePica/AvaTax/Model/Service/Avatax/Invoice.php
@@ -151,8 +151,8 @@ class OnePica_AvaTax_Model_Service_Avatax_Invoice extends OnePica_AvaTax_Model_S
         $this->_addGwPrintedCardAmount($creditmemo, true);
 
         $this->_addAdjustments(
-            $creditmemo->getAdjustmentPositive(),
-            $creditmemo->getAdjustmentNegative(),
+            $creditmemo->getBaseAdjustmentPositive(),
+            $creditmemo->getBaseAdjustmentNegative(),
             $order->getStoreId()
         );
         $this->_setOriginAddress($order->getStoreId());

--- a/app/code/community/OnePica/AvaTax/Model/Service/Avatax16/Invoice.php
+++ b/app/code/community/OnePica/AvaTax/Model/Service/Avatax16/Invoice.php
@@ -141,8 +141,8 @@ class OnePica_AvaTax_Model_Service_Avatax16_Invoice extends OnePica_AvaTax_Model
         $this->_addGwPrintedCardAmount($creditmemo, true);
 
         $this->_addAdjustments(
-            $creditmemo->getAdjustmentPositive(),
-            $creditmemo->getAdjustmentNegative(),
+            $creditmemo->getBaseAdjustmentPositive(),
+            $creditmemo->getBaseAdjustmentNegative(),
             $order->getStoreId()
         );
 


### PR DESCRIPTION
]- Fixed sending wrong Adjustments for creditmemo