### PR TITLE
fixed AV-57 : Admin. AvaTax Configuration. Address Normalization Valu…

### DIFF
--- a/app/code/community/OnePica/AvaTax/Model/Source/Addressvalidation.php
+++ b/app/code/community/OnePica/AvaTax/Model/Source/Addressvalidation.php
@@ -49,15 +49,15 @@ class OnePica_AvaTax_Model_Source_Addressvalidation
         return array(
             array(
                 'value' => self::DISABLED,
-                'label' => Mage::helper('avatax')->__('Disabled')
+                'label' => Mage::helper('avatax')->__('Disable')
             ),
             array(
                 'value' => self::ENABLED_PREVENT_ORDER,
-                'label' => Mage::helper('avatax')->__('Enabled + Prevent Order')
+                'label' => Mage::helper('avatax')->__('Enable + Prevent Order')
             ),
             array(
                 'value' => self::ENABLED_ALLOW_ORDER,
-                'label' => Mage::helper('avatax')->__('Enabled + Allow Order')
+                'label' => Mage::helper('avatax')->__('Enable + Allow Order')
             )
         );
     }


### PR DESCRIPTION
…es are incorrect

Notes :
Please restore previous values and change values for Address Validation from Enabled/Disabled to Enable/Disable so it use default Magento naming.