### PR TITLE
add store filter for collection to load correct tax_class_id when called in admin area

### DIFF
--- a/app/code/community/OnePica/AvaTax/Model/Service/Avatax/Abstract.php
+++ b/app/code/community/OnePica/AvaTax/Model/Service/Avatax/Abstract.php
@@ -312,7 +312,7 @@ abstract class OnePica_AvaTax_Model_Service_Avatax_Abstract extends OnePica_AvaT
      * @param Mage_Sales_Model_Mysql4_Order_Invoice_Item_Collection|array $items
      * @return $this
      */
-    protected function _initProductCollection($items)
+    protected function _initProductCollection($items, $store_id = null)
     {
         $productIds = array();
         foreach ($items as $item) {
@@ -327,6 +327,9 @@ abstract class OnePica_AvaTax_Model_Service_Avatax_Abstract extends OnePica_AvaT
         $this->_productCollection = Mage::getModel('catalog/product')->getCollection()
             ->addAttributeToSelect('*')
             ->addAttributeToFilter('entity_id', array('in' => $productIds));
+        // add store filter for collection to load correct tax_class_id when called in admin area
+        if ($store_id)
+             $this->_productCollection->setStoreId($store_id);
         return $this;
     }
 

--- a/app/code/community/OnePica/AvaTax/Model/Service/Avatax/Invoice.php
+++ b/app/code/community/OnePica/AvaTax/Model/Service/Avatax/Invoice.php
@@ -64,7 +64,7 @@ class OnePica_AvaTax_Model_Service_Avatax_Invoice extends OnePica_AvaTax_Model_S
         $this->_addGeneralInfo($order);
         $this->_addShipping($invoice);
         $items = $invoice->getItemsCollection();
-        $this->_initProductCollection($items);
+        $this->_initProductCollection($items,$storeId);
         $this->_initTaxClassCollection($invoice);
         //Added code for calculating tax for giftwrap items
         $this->_addGwOrderAmount($invoice);
@@ -143,7 +143,7 @@ class OnePica_AvaTax_Model_Service_Avatax_Invoice extends OnePica_AvaTax_Model_S
         $this->_addShipping($creditmemo, true);
 
         $items = $creditmemo->getAllItems();
-        $this->_initProductCollection($items);
+        $this->_initProductCollection($items,$storeId);
         $this->_initTaxClassCollection($creditmemo);
         //Added code for calculating tax for giftwrap items
         $this->_addGwOrderAmount($creditmemo, true);


### PR DESCRIPTION
When multisite architecture is implemented and tax_class_id is set per website. The global tax_class_id is sent to avatax.
Added a store filter for both functions `OnePica_AvaTax_Model_Service_Avatax_Invoice::invoice()` and `OnePica_AvaTax_Model_Service_Avatax_Invoice::creditmemo()` to set up the correct store_id instead of the admin store.

The bug doesn't appear when estimating tax because the right front store will be set automatically (`see Mage_Catalog_Model_Resource_Product_Collection ::_prepareProductLimitationFilters()`)