### PR TITLE
Fix check if mage registry "avatax_store_id" is the admin store Id 0

### DIFF
--- a/app/code/community/OnePica/AvaTax/Model/Observer/SalesQuoteLoadAfter.php
+++ b/app/code/community/OnePica/AvaTax/Model/Observer/SalesQuoteLoadAfter.php
@@ -33,7 +33,7 @@ class OnePica_AvaTax_Model_Observer_SalesQuoteLoadAfter extends OnePica_AvaTax_M
     public function execute(Varien_Event_Observer $observer)
     {
         $storeId = $observer->getEvent()->getQuote()->getStoreId();
-        if (Mage::registry('avatax_store_id')) {
+        if (!is_null(Mage::registry('avatax_store_id'))) {
             Mage::unregister('avatax_store_id');
         }
 


### PR DESCRIPTION
Customer accounts were unaccessible in the admin view.